### PR TITLE
Add host argument to app.listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ app.use(cors())
 app.use(bodyParser.json())
 
 const port = process.env.PORT || 4000
+const host = '127.0.0.1'
 
 app.get("/cards", (request, response) => {
     Card.query().withGraphFetched('stories').then(cards => {
@@ -199,4 +200,4 @@ async function authenticate(request, response, next){
 }
 
 
-app.listen(port)
+app.listen(port, host)


### PR DESCRIPTION
Added host argument so that the backend listens only on localhost - by default it listens on all interfaces, meaning the plain Node process is running on a public port. Not sure if this is a change you want, but seems like it might be sensible to restrict for now.